### PR TITLE
Upload event poster now accepts more image file types

### DIFF
--- a/EventLotterySystemApplication/app/src/main/java/com/example/eventlotterysystemapplication/Model/ImageStorage.java
+++ b/EventLotterySystemApplication/app/src/main/java/com/example/eventlotterysystemapplication/Model/ImageStorage.java
@@ -53,7 +53,7 @@ public class ImageStorage {
     }
 
     /**
-     * Uploads or replaces an event poster image (.png, .jpg, .jpeg) into Firebase Storage
+     * Uploads or replaces an event poster image (.png, .jpg, .jpeg, .gif, .svg, .webp) into Firebase Storage
      * @param eventId The event ID (e.g. a png file will be stored as {eventId}.png)
      * @param eventPosterFile The local image file of the file
      * @param imageUrlListener An OnCompleteListener that obtains the download url link of the image (to be stored in Event object)
@@ -72,10 +72,13 @@ public class ImageStorage {
         String eventPosterName = eventPosterFile.getName().toLowerCase();
         if (!eventPosterName.endsWith(".png") &&
             !eventPosterName.endsWith(".jpg") &&
-            !eventPosterName.endsWith(".jpeg")
+            !eventPosterName.endsWith(".jpeg") &&
+            !eventPosterName.endsWith(".gif") &&
+            !eventPosterName.endsWith(".svg") &&
+            !eventPosterName.endsWith(".webp")
         ) {
             Log.d(TAG, "event poster file name: " + eventPosterName);
-            throw new IllegalArgumentException("File is not an accepted image type (.png, .jpg, or .jpeg)");
+            throw new IllegalArgumentException("File is not an accepted image type (.png, .jpg, .jpeg, .gif, .svg, or .webp)");
         }
 
         Uri eventPosterFileUri = Uri.fromFile(eventPosterFile);
@@ -128,6 +131,7 @@ public class ImageStorage {
      * Given an eventId, delete the associated event poster stored on the storage bucket
      * This function assumes that the eventId poster is stored as an .jpg file which may lead to errors.
      * Therefore, use the posterDownloadUrl deleteEventPoster function if possible.
+     * @deprecated Images can now be any file extension other than .jpg
      * @param listener A void OnCompleteListener that will be called upon delete task completion
      * @param eventId The eventId of the event image poster (may or may not have an associated image so beware)
      * @return An asynchronous void task used ONLY for integration testing purposes. Please do not

--- a/EventLotterySystemApplication/app/src/main/java/com/example/eventlotterysystemapplication/View/CreateOrEditEventFragment.java
+++ b/EventLotterySystemApplication/app/src/main/java/com/example/eventlotterysystemapplication/View/CreateOrEditEventFragment.java
@@ -16,6 +16,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.MimeTypeMap;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.CheckBox;
@@ -664,8 +665,11 @@ public class CreateOrEditEventFragment extends Fragment {
         }
 
         try {
+            String suffix = MimeTypeMap.getSingleton().getExtensionFromMimeType(getContext().getContentResolver().getType(uri));
+            Log.d(TAG, "file uri: " + uri);
+            Log.d(TAG, "image suffix: " + suffix);
             // Create temp image file for poster
-            File tempFile = File.createTempFile("temp_image", ".jpg");
+            File tempFile = File.createTempFile("temp_image", "." + suffix);
 
             InputStream inputStream = getContext().getContentResolver().openInputStream(uri);
             if (inputStream == null) {


### PR DESCRIPTION
You can now upload any image type for your event posters (.png, .jpg, .jpeg, .gif, .svg, or .webp) 